### PR TITLE
atomsの汎用ボタンを少し具体化したボタンを定義。

### DIFF
--- a/src/component/molecules/button/Button.Molecules.css
+++ b/src/component/molecules/button/Button.Molecules.css
@@ -1,0 +1,36 @@
+/* 基本のスタイル */
+.round-white-button {
+  border: 1px solid lightgrey; /* ボーダーを薄いグレーに設定 */
+  border-radius: 50px; /* 丸みをつける */
+  font-size: 1rem; /* テキストサイズ */
+  cursor: pointer; /* 通常時のカーソルをポインターに */
+  transition: all 0.3s ease; /* スムーズなアニメーション */
+}
+
+/* 基本スタイル */
+.selected-white-button {
+  background-color: white; /* デフォルトの背景色 */
+  color: grey; /* テキストの色 */
+  border: 1px solid lightgrey; /* デフォルトのボーダー */
+  padding: 10px 20px; /* 内側の余白 */
+  border-radius: 5px; /* 角丸 */
+  cursor: pointer; /* カーソルをポインターに */
+  transition: all 0.3s ease; /* スムーズなスタイル変更 */
+}
+
+/* 選択状態のスタイル */
+.selected-white-button.selected {
+  background-color: #f0f0f0; /* 選択時の背景色 */
+  color: grey; /* 選択時のテキスト色 */
+  border: 0.5px solid grey; /* 選択時のボーダー */
+  box-shadow: none; /* 選択時は影をなくす */
+}
+
+/* 無効状態のスタイル */
+.selected-white-button:disabled {
+  background-color: #f3f3f3; /* 無効時の背景色 */
+  color: #a9a9a9; /* 無効時のテキスト色 */
+  cursor: not-allowed; /* 無効時のカーソル */
+  border: 1px solid #e0e0e0; /* 無効時のボーダー */
+  box-shadow: none; /* 無効時は影をなくす */
+}

--- a/src/component/molecules/button/RoundWhiteButton.tsx
+++ b/src/component/molecules/button/RoundWhiteButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ButtonAtoms from '../../atoms/button/ButtonAtoms';
+import './Button.Molecules.css';
+
+interface LogoProps {
+  text: string; // 画像のソースを指定するプロパティ
+  onClick: () => void; // クリックイベントを受け取るプロパティ
+  disabled?: boolean; // ボタンの無効化状態
+}
+
+const RoundWhiteButton: React.FC<LogoProps> = ({ text, onClick, disabled }) => {
+  return (
+    <ButtonAtoms
+      text={text}
+      className="round-white-button"
+      onClick={onClick}
+      disabled={disabled}
+    />
+  );
+};
+
+export default RoundWhiteButton;

--- a/src/component/molecules/button/SelectedWhiteButton.tsx
+++ b/src/component/molecules/button/SelectedWhiteButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ButtonAtoms from '../../atoms/button/ButtonAtoms';
+import './Button.Molecules.css';
+
+interface LogoProps {
+  text: string; // ボタンのテキスト
+  isSelected?: boolean; // 選択状態
+  onClick: () => void; // クリックイベントを受け取るプロパティ
+  disabled?: boolean; // ボタンの無効化状態
+}
+
+const SelectedWhiteButton: React.FC<LogoProps> = ({
+  text,
+  onClick,
+  isSelected,
+  disabled,
+}) => {
+  return (
+    <ButtonAtoms
+      text={text}
+      className={`selected-white-button ${isSelected ? 'selected' : ''}`}
+      onClick={onClick}
+      disabled={disabled}
+    />
+  );
+};
+
+export default SelectedWhiteButton;


### PR DESCRIPTION
丸みを帯びた、背景白色ボタンと、selected状態を指定できるボタンの二種類を用意してある。必要な場合は、随時これと同様に汎用具体化ボタンを追加していく予定。