### PR TITLE
atomsのchekboxをgrid上に並べるコンポーネントをmolecules層でデザイン&テスト付きで定義。

### DIFF
--- a/src/component/molecules/checkboxGrid/CheckboxGrid.css
+++ b/src/component/molecules/checkboxGrid/CheckboxGrid.css
@@ -1,0 +1,34 @@
+/* グリッドコンテナのスタイル */
+.grid-container {
+  display: grid; /* グリッドレイアウトを有効化 */
+  gap: 1rem; /* グリッド項目間のスペース */
+}
+
+/* グリッドの列設定 (カスタマイズ可能な部分) */
+.grid-container.columns-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr)); /* 2列レイアウト */
+}
+
+.grid-container.columns-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr)); /* 3列レイアウト */
+}
+
+.grid-container.columns-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr)); /* 4列レイアウト */
+}
+
+.grid-container.columns-5 {
+  grid-template-columns: repeat(5, minmax(0, 1fr)); /* 4列レイアウト */
+}
+
+.grid-container.columns-6 {
+  grid-template-columns: repeat(6, minmax(0, 1fr)); /* 4列レイアウト */
+}
+
+.grid-container.columns-7 {
+  grid-template-columns: repeat(7, minmax(0, 1fr)); /* 4列レイアウト */
+}
+
+.grid-container.columns-8 {
+  grid-template-columns: repeat(8, minmax(0, 1fr)); /* 4列レイアウト */
+}

--- a/src/component/molecules/checkboxGrid/CheckboxGrid.tsx
+++ b/src/component/molecules/checkboxGrid/CheckboxGrid.tsx
@@ -1,0 +1,37 @@
+// molecules/CheckboxGrid.tsx
+import React from 'react';
+import Checkbox from '../../atoms/checkbox/CheckboxAtoms';
+import './CheckboxGrid.css';
+
+interface CheckboxOption {
+  label: string; // チェックボックスのラベル
+  onChange: () => void; // チェックボックスの変更イベント
+  checked: boolean; // チェック状態
+  disabled?: boolean; // チェックボックスの無効化状態
+}
+
+interface CheckboxGridProps {
+  options: CheckboxOption[]; // チェックボックスのオプション
+  columns?: number; // カラム数
+}
+
+const CheckboxGrid: React.FC<CheckboxGridProps> = ({
+  options,
+  columns = 3, // Default to 3 columns
+}) => {
+  return (
+    <div className={`grid-container columns-${columns}`}>
+      {options.map((option, index) => (
+        <Checkbox
+          key={index}
+          label={option.label}
+          checked={option.checked}
+          disabled={option.disabled}
+          onChange={() => option.onChange()}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default CheckboxGrid;

--- a/src/component/molecules/checkboxGrid/__tests__/CheckboxGrid.test.tsx
+++ b/src/component/molecules/checkboxGrid/__tests__/CheckboxGrid.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import CheckboxGrid from '../CheckboxGrid';
+
+describe('CheckboxGrid Component', () => {
+  const mockOnChange = jest.fn();
+  const mockOptions = [
+    { label: 'Option 1', checked: false, onChange: mockOnChange },
+    { label: 'Option 2', checked: true, onChange: mockOnChange },
+    {
+      label: 'Option 3',
+      checked: false,
+      onChange: mockOnChange,
+      disabled: true,
+    },
+  ];
+
+  // チェックボックスの個数が正しいことを確認
+  test('renders the correct number of checkboxes', () => {
+    render(<CheckboxGrid options={mockOptions} columns={2} />);
+
+    const checkboxes = screen.getAllByTestId('checkbox-input');
+    expect(checkboxes).toHaveLength(mockOptions.length);
+  });
+
+  // チェックボックスの各ラベルが正しく表示されることを確認
+  test('renders the labels correctly', () => {
+    render(<CheckboxGrid options={mockOptions} columns={2} />);
+
+    mockOptions.forEach((option) => {
+      expect(screen.getByText(option.label)).toBeInTheDocument();
+    });
+  });
+
+  // チェックボックスがクリックされたときに、正しくonChangeが呼び出されることを確認
+  test('calls onChange with the correct arguments when a checkbox is clicked', () => {
+    render(<CheckboxGrid options={mockOptions} columns={2} />);
+
+    const checkbox = screen.getAllByTestId('checkbox-input')[0];
+    fireEvent.click(checkbox);
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+  });
+
+  // オプションに基づいてチェックボックスを正しく無効にすることを確認
+  test('disables checkboxes correctly based on the options', () => {
+    render(<CheckboxGrid options={mockOptions} columns={2} />);
+
+    const checkboxes = screen.getAllByTestId('checkbox-input');
+
+    expect(checkboxes[0]).not.toBeDisabled();
+    expect(checkboxes[1]).not.toBeDisabled();
+    expect(checkboxes[2]).toBeDisabled();
+  });
+});


### PR DESCRIPTION
テストは全て突破したことを確認済み。親コンポーネントの幅に応じて自動でcolumnsを調整するロジックを追加すると、後々楽になると思う。