### PR TITLE
都道府県の選択のロジックを定義。テストも実装。

### DIFF
--- a/src/hooks/__tests__/useSelectedPrefectures.test.tsx
+++ b/src/hooks/__tests__/useSelectedPrefectures.test.tsx
@@ -1,0 +1,80 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { PrefectureType } from '../../interface/prefecture';
+import useSelectedPrefectures from '../useSelectedPrefectures';
+
+describe('useSelectedPrefectures', () => {
+  // テストデータ
+  const mockPrefecture1: PrefectureType = {
+    prefCode: 1,
+    prefName: '北海道',
+  };
+
+  const mockPrefecture2: PrefectureType = {
+    prefCode: 2,
+    prefName: '青森県',
+  };
+
+  it('should return an empty array initially.', () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    expect(result.current.prefectures).toEqual([]);
+  });
+
+  it('should add a prefecture', () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.handleSelectedPrefectures(mockPrefecture1);
+    });
+
+    expect(result.current.prefectures).toEqual([mockPrefecture1]);
+  });
+
+  it('should add prefectures', () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.handleSelectedPrefectures(mockPrefecture1);
+      result.current.handleSelectedPrefectures(mockPrefecture2);
+    });
+
+    expect(result.current.prefectures).toEqual([
+      mockPrefecture1,
+      mockPrefecture2,
+    ]);
+  });
+
+  it('Should delete already selected prefectures', () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    // まず都道府県を追加
+    act(() => {
+      result.current.handleSelectedPrefectures(mockPrefecture1);
+      result.current.handleSelectedPrefectures(mockPrefecture2);
+    });
+
+    // 同じ都道府県を再度選択して削除
+    act(() => {
+      result.current.handleSelectedPrefectures(mockPrefecture1);
+    });
+
+    expect(result.current.prefectures).toEqual([mockPrefecture2]);
+  });
+
+  it('Should remove all prefectures.', () => {
+    const { result } = renderHook(() => useSelectedPrefectures());
+
+    act(() => {
+      result.current.handleSelectedPrefectures(mockPrefecture1);
+      result.current.handleSelectedPrefectures(mockPrefecture2);
+    });
+
+    act(() => {
+      result.current.handleSelectedPrefectures(mockPrefecture1);
+      result.current.handleSelectedPrefectures(mockPrefecture2);
+    });
+
+    expect(result.current.prefectures).toEqual([]);
+  });
+});

--- a/src/hooks/useSelectedPrefectures.tsx
+++ b/src/hooks/useSelectedPrefectures.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { PrefectureType } from '../interface/prefecture';
+
+// フックの戻り値の型を定義
+interface UseSelectedPrefecturesReturn {
+  prefectures: PrefectureType[];
+  handleSelectedPrefectures: (prefecture: PrefectureType) => void;
+}
+
+const useSelectedPrefectures = (): UseSelectedPrefecturesReturn => {
+  const [prefectures, setPrefectures] = useState<PrefectureType[]>([]); // 初期値は6カラム
+
+  const handleSelectedPrefectures = (prefecture: PrefectureType) => {
+    if (
+      prefectures
+        .map((pref: PrefectureType) => pref.prefCode)
+        .includes(prefecture.prefCode)
+    ) {
+      setPrefectures((prevPrefectures) =>
+        prevPrefectures.filter(
+          (pref: PrefectureType) => pref.prefCode !== prefecture.prefCode,
+        ),
+      );
+    } else {
+      setPrefectures((prevPrefectures) => [...prevPrefectures, prefecture]);
+    }
+  };
+
+  return { prefectures, handleSelectedPrefectures }; // カラム数を返す
+};
+
+export default useSelectedPrefectures;


### PR DESCRIPTION
handleSelectedPrefecturesでは、すでに配列に保管されているprefectureなら削除、そうでなければ追加する。
テストは全て突破済み。