### PR TITLE
labelをクリックしたときに、checkboxのonchangeがハッカしない問題を解消。

### DIFF
--- a/src/component/atoms/checkbox/CheckboxAtoms.tsx
+++ b/src/component/atoms/checkbox/CheckboxAtoms.tsx
@@ -18,6 +18,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
     <div className="checkbox-container">
       <input
         type="checkbox"
+        id={'checkbox-' + label} // ユニークなIDを指定
         data-testid="checkbox-input"
         checked={checked}
         onChange={() => {
@@ -28,7 +29,15 @@ const Checkbox: React.FC<CheckboxProps> = ({
         disabled={disabled}
         className="checkbox-input"
       />
-      <label className="checkbox-label" data-testid="checkbox-atoms-label">
+      <label
+        onClick={() => {
+          if (!disabled) {
+            onChange();
+          }
+        }}
+        className="checkbox-label"
+        data-testid="checkbox-atoms-label"
+      >
         {label}
       </label>
     </div>

--- a/src/component/atoms/checkbox/__tests__/CheckboxAtoms.test.tsx
+++ b/src/component/atoms/checkbox/__tests__/CheckboxAtoms.test.tsx
@@ -45,6 +45,15 @@ describe('Checkbox', () => {
     expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onChange handler when label clicked', () => {
+    render(<Checkbox {...defaultProps} />);
+
+    const label = screen.getByTestId('checkbox-atoms-label');
+    fireEvent.click(label);
+
+    expect(defaultProps.onChange).toHaveBeenCalledTimes(1);
+  });
+
   it('is disabled when disabled prop is true', () => {
     render(<Checkbox {...defaultProps} disabled={true} />);
 


### PR DESCRIPTION
テストも修正し、ローカルでは全て突破済み。