### PR TITLE
ユニットテストのカバレッジ不足だった部分を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest",
+    "test": "jest --coverage",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {

--- a/src/component/molecules/checkboxGrid/CheckboxGrid.tsx
+++ b/src/component/molecules/checkboxGrid/CheckboxGrid.tsx
@@ -20,7 +20,10 @@ const CheckboxGrid: React.FC<CheckboxGridProps> = ({
   columns = 3, // Default to 3 columns
 }) => {
   return (
-    <div className={`grid-container columns-${columns}`}>
+    <div
+      data-testid="checkbox-grid"
+      className={`grid-container columns-${columns}`}
+    >
       {options.map((option, index) => (
         <Checkbox
           key={index}

--- a/src/component/molecules/checkboxGrid/__tests__/CheckboxGrid.test.tsx
+++ b/src/component/molecules/checkboxGrid/__tests__/CheckboxGrid.test.tsx
@@ -14,6 +14,22 @@ describe('CheckboxGrid Component', () => {
     },
   ];
 
+  // columnsの数が明示的に指定されていない場合、デフォルト値が使用されることを確認
+  test('uses the default number of columns if not explicitly specified', () => {
+    render(<CheckboxGrid options={mockOptions} />);
+
+    const grid = screen.getByTestId('checkbox-grid');
+    expect(grid).toHaveClass('columns-3');
+  });
+
+  // columnsの数が明示的に指定されてる場合、指定された数が使用されることを確認
+  test('uses the default number of columns if not explicitly specified', () => {
+    render(<CheckboxGrid options={mockOptions} columns={4} />);
+
+    const grid = screen.getByTestId('checkbox-grid');
+    expect(grid).toHaveClass('columns-4');
+  });
+
   // チェックボックスの個数が正しいことを確認
   test('renders the correct number of checkboxes', () => {
     render(<CheckboxGrid options={mockOptions} columns={2} />);
@@ -29,6 +45,11 @@ describe('CheckboxGrid Component', () => {
     mockOptions.forEach((option) => {
       expect(screen.getByText(option.label)).toBeInTheDocument();
     });
+  });
+
+  test('renders no checkboxes when options is empty', () => {
+    render(<CheckboxGrid options={[]} />);
+    expect(screen.queryByRole('checkbox')).toBeNull(); // Checkboxが一つもレンダリングされない
   });
 
   // チェックボックスがクリックされたときに、正しくonChangeが呼び出されることを確認

--- a/src/hooks/__tests__/useMode.test.tsx
+++ b/src/hooks/__tests__/useMode.test.tsx
@@ -8,6 +8,12 @@ describe('useMode', () => {
   const mockLabel: PopulationLabel = '年少人口';
 
   it('should return an default value initially.', () => {
+    const { result } = renderHook(() => useMode());
+
+    expect(result.current.mode).toEqual(mockLabel);
+  });
+
+  it('should return value initially.', () => {
     const init: PopulationLabel = '生産年齢人口';
     const { result } = renderHook(() => useMode(init));
 


### PR DESCRIPTION
チェックボックスと、modeの初期値に関するものだった。初期値を代入するかどうかの分岐がなかった。