### PR TITLE
返り値の型と内部制御を簡略化。

### DIFF
--- a/src/hooks/useGetPopulation.tsx
+++ b/src/hooks/useGetPopulation.tsx
@@ -1,24 +1,15 @@
-import {
-  useQueries,
-  useQueryClient,
-  UseQueryResult,
-} from '@tanstack/react-query';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { PopulationType } from '../interface/population';
 import { PrefectureType } from '../interface/prefecture';
 import { getPopulation } from '../services/api/population/getPopulation';
 
-interface QueryState<T>
-  extends Pick<
-    UseQueryResult<T>,
-    'isLoading' | 'isError' | 'error' | 'status'
-  > {
-  data: T | undefined;
-}
-
-// React Query用のカスタムフック
 export const useGetPopulation = (
   prefecures: PrefectureType[],
-): QueryState<PopulationType[]> => {
+): {
+  data?: PopulationType[];
+  isLoading: boolean;
+  isError: boolean;
+} => {
   const queryClient = useQueryClient();
 
   const populationQueries = useQueries({
@@ -28,31 +19,22 @@ export const useGetPopulation = (
       // キャッシュの設定
       staleTime: 5 * 60 * 1000, // 5分間はキャッシュを新鮮として扱う
       cacheTime: 30 * 60 * 1000, // 30分間キャッシュを保持
-      // オプションでプリフェッチしたデータを使用
       initialData: () => {
         return queryClient.getQueryData(['prefecture', pref.prefCode]);
       },
     })),
   });
 
-  // 全てのクエリの状態を集約
   const isLoading = populationQueries.some((query) => query.isLoading);
   const isError = populationQueries.some((query) => query.isError);
-  const error = populationQueries.find((query) => query.error)?.error ?? null;
-  const status = isLoading ? 'pending' : isError ? 'error' : 'success';
-  // 型安全なフィルタリング処理
-  const data =
-    isLoading || isError
-      ? undefined
-      : populationQueries
-          .map((query) => query.data)
-          .filter((data): data is PopulationType => data !== undefined);
+
+  const data = populationQueries
+    .map((query) => query.data)
+    .filter((data): data is PopulationType => data !== undefined);
 
   return {
     data,
     isLoading,
     isError,
-    error,
-    status,
   };
 };


### PR DESCRIPTION
これだけ簡素な作りになっているのであれば、useGetPrefecturesと同様にして、APIテストのみで十分な気がする。このhooksまでテストを実装しなくても問題はなさそうに思える。