### PR TITLE
新規会員登録を行うAPI(サーバー)が存在しないため、仕方なくReduxに保管する。

### DIFF
--- a/src/app/redux/slice/__tests__/userSlice.test.ts
+++ b/src/app/redux/slice/__tests__/userSlice.test.ts
@@ -1,0 +1,34 @@
+import userReducer, { registerUser } from './../userSlice';
+
+describe('userSlice', () => {
+  const initialState = {
+    email: 'test@example.com',
+    password: 'password',
+  };
+
+  it('should return the initial state when passed an empty action', () => {
+    const result = userReducer(undefined, { type: '' });
+    expect(result).toEqual(initialState);
+  });
+
+  it('should handle registerUser action', () => {
+    const payload = { email: 'test2@example.com', password: 'password123' };
+    const action = registerUser(payload);
+
+    const result = userReducer(initialState, action);
+
+    expect(result.email).toBe(payload.email);
+    expect(result.password).toBe(payload.password);
+  });
+
+  it('should override state when registerUser is called multiple times', () => {
+    const initial = { email: 'old@example.com', password: 'oldpassword' };
+    const newPayload = { email: 'new@example.com', password: 'newpassword' };
+    const action = registerUser(newPayload);
+
+    const result = userReducer(initial, action);
+
+    expect(result.email).toBe(newPayload.email);
+    expect(result.password).toBe(newPayload.password);
+  });
+});

--- a/src/app/redux/slice/userSlice.ts
+++ b/src/app/redux/slice/userSlice.ts
@@ -1,0 +1,28 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface UserState {
+  email: string;
+  password: string;
+}
+
+const initialState: UserState = {
+  email: 'test@example.com',
+  password: 'password',
+};
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {
+    registerUser: (
+      state,
+      action: PayloadAction<{ email: string; password: string }>,
+    ) => {
+      state.email = action.payload.email;
+      state.password = action.payload.password;
+    },
+  },
+});
+
+export const { registerUser } = userSlice.actions;
+export default userSlice.reducer;

--- a/src/app/redux/store.ts
+++ b/src/app/redux/store.ts
@@ -1,13 +1,16 @@
 import { configureStore } from '@reduxjs/toolkit';
 import authReducer, { AuthState } from './slice/authSlice';
+import userReducer, { UserState } from './slice/userSlice';
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    user: userReducer,
   },
 });
 
 export type RootState = {
   auth: AuthState;
+  user: UserState;
 };
 export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
セキュリティの都合から、このような処置は絶対に行うべきではない。
しかしながら、今回はフロントエンドのみの開発であるため、簡易的にreduxにフルユーザー情報を保存する。
ログイン判定に用いる。